### PR TITLE
feat: bridgeless mode

### DIFF
--- a/ReactNativeFastImageExample/src/index.tsx
+++ b/ReactNativeFastImageExample/src/index.tsx
@@ -13,9 +13,6 @@ LogBox.ignoreLogs([
   'Warning: isMounted(...) is deprecated',
   'Module RCTImageLoader',
 ]);
-const uiManager = global?.nativeFabricUIManager ? 'Fabric' : 'Paper';
-
-console.log('Running on',uiManager)
 
 export default function App() {
   return (

--- a/ReactNativeFastImageExample/src/index.tsx
+++ b/ReactNativeFastImageExample/src/index.tsx
@@ -13,6 +13,9 @@ LogBox.ignoreLogs([
   'Warning: isMounted(...) is deprecated',
   'Module RCTImageLoader',
 ]);
+const uiManager = global?.nativeFabricUIManager ? 'Fabric' : 'Paper';
+
+console.log('Running on',uiManager)
 
 export default function App() {
   return (

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
@@ -8,9 +8,14 @@ import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.ImageViewTarget;
 import com.bumptech.glide.request.target.Target;
 import com.facebook.react.bridge.WritableMap;
+import com.dylanvann.fastimage.events.FastImageErrorEvent;
+import com.dylanvann.fastimage.events.FastImageLoadEndEvent;
+import com.dylanvann.fastimage.events.FastImageLoadEvent;
+import com.dylanvann.fastimage.events.FastImageProgressEvent;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.events.EventDispatcher;
 
 public class FastImageRequestListener implements RequestListener<Drawable> {
     static final String REACT_ON_ERROR_EVENT = "onFastImageError";
@@ -37,10 +42,13 @@ public class FastImageRequestListener implements RequestListener<Drawable> {
         }
         FastImageViewWithUrl view = (FastImageViewWithUrl) ((ImageViewTarget) target).getView();
         ThemedReactContext context = (ThemedReactContext) view.getContext();
-        RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
-        int viewId = view.getId();
-        eventEmitter.receiveEvent(viewId, REACT_ON_ERROR_EVENT, new WritableNativeMap());
-        eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, new WritableNativeMap());
+        EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
+        int surfaceId = UIManagerHelper.getSurfaceId(view);
+
+        if (dispatcher != null) {
+            dispatcher.dispatchEvent(new FastImageErrorEvent(surfaceId, view.getId(), null));
+            dispatcher.dispatchEvent(new FastImageLoadEndEvent(surfaceId, view.getId()));
+        }
         return false;
     }
 
@@ -51,10 +59,13 @@ public class FastImageRequestListener implements RequestListener<Drawable> {
         }
         FastImageViewWithUrl view = (FastImageViewWithUrl) ((ImageViewTarget) target).getView();
         ThemedReactContext context = (ThemedReactContext) view.getContext();
-        RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
-        int viewId = view.getId();
-        eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_EVENT, mapFromResource(resource));
-        eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_END_EVENT, new WritableNativeMap());
+        EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
+        int surfaceId = UIManagerHelper.getSurfaceId(view);
+
+        if (dispatcher != null) {
+            dispatcher.dispatchEvent(new FastImageLoadEvent(surfaceId, view.getId()));
+            dispatcher.dispatchEvent(new FastImageLoadEndEvent(surfaceId, view.getId()));
+        }
         return false;
     }
 }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -14,14 +14,19 @@ import androidx.annotation.NonNull;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
+import com.dylanvann.fastimage.events.FastImageProgressEvent;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.common.ViewUtil;
+import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 
 import java.util.List;
@@ -117,13 +122,17 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         List<FastImageViewWithUrl> viewsForKey = VIEWS_FOR_URLS.get(key);
         if (viewsForKey != null) {
             for (FastImageViewWithUrl view : viewsForKey) {
-                WritableMap event = new WritableNativeMap();
-                event.putInt("loaded", (int) bytesRead);
-                event.putInt("total", (int) expectedLength);
-                ThemedReactContext context = (ThemedReactContext) view.getContext();
-                RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
-                int viewId = view.getId();
-                eventEmitter.receiveEvent(viewId, REACT_ON_PROGRESS_EVENT, event);
+                ReactContext context = getReactApplicationContext();
+                EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.getId());
+                FastImageProgressEvent event = new FastImageProgressEvent(
+                        ViewUtil.NO_SURFACE_ID,
+                        view.getId(),
+                        (int) bytesRead,
+                        (int) expectedLength);
+
+                if (dispatcher != null) {
+                    dispatcher.dispatchEvent(event);
+                }
             }
         }
     }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -14,10 +14,11 @@ import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.request.Request;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.WritableNativeMap;
+import com.dylanvann.fastimage.events.FastImageErrorEvent;
+import com.dylanvann.fastimage.events.FastImageLoadStartEvent;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.events.EventDispatcher;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -75,12 +76,9 @@ class FastImageViewWithUrl extends AppCompatImageView {
             setImageDrawable(null);
             
             ThemedReactContext context = (ThemedReactContext) getContext();
-            RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
-            int viewId = getId();
-            WritableMap event = new WritableNativeMap();
-            event.putString("message", "Image source uri cannot be empty or null:" + mSource);
-            eventEmitter.receiveEvent(viewId, REACT_ON_ERROR_EVENT, event);
-
+            EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
+            int surfaceId = UIManagerHelper.getSurfaceId(this);
+            FastImageErrorEvent event = new FastImageErrorEvent(surfaceId, getId(), mSource);
             return;
         }
 
@@ -89,12 +87,13 @@ class FastImageViewWithUrl extends AppCompatImageView {
 
         if (imageSource != null && imageSource.getUri().toString().length() == 0) {
             ThemedReactContext context = (ThemedReactContext) getContext();
-            RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
-            int viewId = getId();
-            WritableMap event = new WritableNativeMap();
-            event.putString("message", "Invalid source prop: " + mSource);
-            eventEmitter.receiveEvent(viewId, REACT_ON_ERROR_EVENT, event);
+            EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
+            int surfaceId = UIManagerHelper.getSurfaceId(this);
+            FastImageErrorEvent event = new FastImageErrorEvent(surfaceId, getId(), mSource);
 
+            if (dispatcher != null) {
+                dispatcher.dispatchEvent(event);
+            }
             // Cancel existing requests.
             clearView(requestManager);
 
@@ -129,12 +128,14 @@ class FastImageViewWithUrl extends AppCompatImageView {
         ThemedReactContext context = (ThemedReactContext) getContext();
         if (imageSource != null) {
             // This is an orphan even without a load/loadend when only loading a placeholder
-            RCTEventEmitter eventEmitter = context.getJSModule(RCTEventEmitter.class);
-            int viewId = this.getId();
+            // This is an orphan event without a load/loadend when only loading a placeholder
+            EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
+            int surfaceId = UIManagerHelper.getSurfaceId(this);
+            FastImageLoadStartEvent event = new FastImageLoadStartEvent(surfaceId, getId());
 
-            eventEmitter.receiveEvent(viewId,
-                    FastImageViewManager.REACT_ON_LOAD_START_EVENT,
-                    new WritableNativeMap());
+            if (dispatcher != null) {
+                dispatcher.dispatchEvent(event);
+            }
         }
 
         if (requestManager != null) {

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageErrorEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageErrorEvent.java
@@ -1,0 +1,34 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageErrorEvent extends Event<FastImageErrorEvent> {
+
+    @Nullable
+    private final ReadableMap mSource;
+
+    public FastImageErrorEvent(int surfaceId, int viewTag, @Nullable ReadableMap source) {
+        super(surfaceId, viewTag);
+        mSource = source;
+    }
+    @NonNull
+    @Override
+    public String getEventName() {
+        return "onFastImageError";
+    }
+
+    @Override
+    protected WritableMap getEventData() {
+        WritableMap eventData = Arguments.createMap();
+        if (mSource != null) {
+            eventData.putString("message", "Invalid source prop:" + mSource);
+        }
+        return eventData;
+    }
+}

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadEndEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadEndEvent.java
@@ -1,0 +1,19 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageLoadEndEvent extends Event<FastImageLoadEndEvent> {
+
+    public FastImageLoadEndEvent(int surfaceId, int viewTag) {
+        super(surfaceId, viewTag);
+    }
+
+    @NonNull
+    @Override
+    public String getEventName() {
+        return "onFastImageLoadEnd";
+    }
+
+}

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadEvent.java
@@ -1,0 +1,19 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageLoadEvent extends Event<FastImageLoadEvent> {
+
+    public FastImageLoadEvent(int surfaceId, int viewTag) {
+        super(surfaceId, viewTag);
+    }
+
+    @NonNull
+    @Override
+    public String getEventName() {
+        return "onFastImageLoad";
+    }
+
+}

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadStartEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageLoadStartEvent.java
@@ -1,0 +1,19 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageLoadStartEvent extends Event<FastImageLoadStartEvent> {
+
+    public FastImageLoadStartEvent(int surfaceId, int viewTag) {
+        super(surfaceId, viewTag);
+    }
+
+    @NonNull
+    @Override
+    public String getEventName() {
+        return "onFastImageLoadStart";
+    }
+
+}

--- a/android/src/main/java/com/dylanvann/fastimage/events/FastImageProgressEvent.java
+++ b/android/src/main/java/com/dylanvann/fastimage/events/FastImageProgressEvent.java
@@ -1,0 +1,34 @@
+package com.dylanvann.fastimage.events;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+
+public class FastImageProgressEvent extends Event<FastImageProgressEvent> {
+
+    private final int mBytesRead;
+    private final int mExpectedLength;
+
+    public FastImageProgressEvent(int surfaceId, int viewTag, int bytesRead, int expectedLength) {
+        super(surfaceId, viewTag);
+        this.mBytesRead = bytesRead;
+        this.mExpectedLength = expectedLength;
+    }
+
+    @NonNull
+    @Override
+    public String getEventName() {
+        return "onFastImageProgress";
+    }
+
+    @Override
+    protected WritableMap getEventData() {
+        WritableMap eventData = Arguments.createMap();
+        eventData.putInt("loaded", mBytesRead);
+        eventData.putInt("total", mExpectedLength);
+        return eventData;
+    }
+
+}


### PR DESCRIPTION
Fixes: https://github.com/DylanVann/react-native-fast-image/issues/1041
It was using  RCTEventEmitter which is deprecated. Using EventDispatcher for supporting bridgeless mode
Original PR : https://github.com/DylanVann/react-native-fast-image/pull/1032 
