### PR TITLE
[Android] Add support for transparent AVIF images

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,12 +78,13 @@ repositories {
     mavenCentral()
 }
 
-def glideVersion = safeExtGet('glideVersion', '4.12.0')
+def glideVersion = safeExtGet('glideVersion', '4.14.2')
 
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation "com.github.bumptech.glide:glide:${glideVersion}"
     implementation "com.github.bumptech.glide:okhttp3-integration:${glideVersion}"
+    implementation "com.github.bumptech.glide:avif-integration:${glideVersion}"
     annotationProcessor "com.github.bumptech.glide:compiler:${glideVersion}"
 }


### PR DESCRIPTION
Hi there,

First of all, thank you for your continued work and support on this project. We've been using a custom patch to address this issue and believe it should now be part of the package.

The Problem: AVIF images with transparent backgrounds are displayed with a black background on Android.

The Solution: Added a Gradle dependency to support transparent AVIF format on Android.