### PR TITLE
Fix a crash on android when the headers property is specified on the …

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -209,9 +209,10 @@ function FastImageBase({
     const FABRIC_ENABLED = !!global?.nativeFabricUIManager
 
     // this type differs based on the `source` prop passed
-    const resolvedSource = Image.resolveAssetSource(
-        source as any,
-    ) as ImageResolvedAssetSource & { headers: any }
+    // spread because the returned object is frozen
+    const resolvedSource = {
+        ...Image.resolveAssetSource(source as any),
+    } as ImageResolvedAssetSource & { headers: any }
     if (
         resolvedSource?.headers &&
         (FABRIC_ENABLED || Platform.OS === 'android')


### PR DESCRIPTION
…source

Fixes https://github.com/dream-sports-labs/react-native-fast-image/issues/210.

The object returned by Image.resolveAssetSource is frozen and can't be modified.