### PR TITLE
docs: update download badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Special thanks to:
 [build]: https://github.com/dream-sports-labs/react-native-fast-image/actions?query=workflow%3ACI
 [coverage-badge]: https://img.shields.io/codecov/c/github/dream-sports-labs/react-native-fast-image.svg
 [coverage]: https://codecov.io/github/dream-sports-labs/react-native-fast-image
-[downloads-badge]: https://img.shields.io/npm/dm/react-native-fast-image.svg
+[downloads-badge]: https://img.shields.io/npm/dm/@d11/react-native-fast-image.svg
 [npmtrends]: http://www.npmtrends.com/@d11/react-native-fast-image
 [package]: https://www.npmjs.com/package/@d11/react-native-fast-image
 [version-badge]: https://img.shields.io/npm/v/@d11/react-native-fast-image.svg


### PR DESCRIPTION
## Summary:

update download badge. The current one is not correct. should be https://img.shields.io/npm/dm/@d11/react-native-fast-image.svg
