### PR TITLE
Fix: failing unit test cases on main

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -209,10 +209,11 @@ function FastImageBase({
     const FABRIC_ENABLED = !!global?.nativeFabricUIManager
 
     // this type differs based on the `source` prop passed
-    // spread because the returned object is frozen
-    const resolvedSource = {
-        ...Image.resolveAssetSource(source as any),
-    } as ImageResolvedAssetSource & { headers: any }
+    const resolvedSource = Image.resolveAssetSource(
+        source as any,
+    ) as ImageResolvedAssetSource & { headers: any }
+    // resolvedSource would be frozen, we can't modify it
+    let modifiedSource = resolvedSource
     if (
         resolvedSource?.headers &&
         (FABRIC_ENABLED || Platform.OS === 'android')
@@ -222,7 +223,7 @@ function FastImageBase({
         Object.keys(resolvedSource.headers).forEach((key) => {
             headersArray.push({ name: key, value: resolvedSource.headers[key] })
         })
-        resolvedSource.headers = headersArray
+        modifiedSource = { ...resolvedSource, headers: headersArray }
     }
     const resolvedDefaultSource = resolveDefaultSource(defaultSource)
     const resolvedDefaultSourceAsString =
@@ -234,7 +235,7 @@ function FastImageBase({
                 {...props}
                 tintColor={tintColor}
                 style={StyleSheet.absoluteFill}
-                source={resolvedSource}
+                source={modifiedSource}
                 defaultSource={resolvedDefaultSourceAsString}
                 onFastImageLoadStart={onLoadStart}
                 onFastImageProgress={onProgress}


### PR DESCRIPTION
## Summary:

The `Image.resolveAssetSource()` method returns a frozen object that cannot be modified. When no source prop was provided to FastImage, the previous implementation used a spread operator on the result of Image.resolveAssetSource(). This caused an empty object {} to be created even when the resolved source was null or undefined.

## Changelog:

[INTERNAL] [FIXED] - Fixed failing unit test cases due to empty object {} to be created even when the resolved source was null or undefined

## Test Plan:

<img width="724" alt="Screenshot 2025-07-08 at 2 45 45 PM" src="https://github.com/user-attachments/assets/f4166bf9-4b22-4a17-84b6-18d737a5354f" />


