### PR TITLE
feat: 80 support added

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.source        = { :git => "https://github.com/DylanVann/react-native-fast-image.git", :tag => "v#{s.version}" }
   if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
     s.pod_target_xcconfig = {
       'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native"  "$(PODS_ROOT)/RCT-Folly"',

--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
         "jsSrcsDir": "./src",
         "android": {
             "javaPackageName": "com.dylanvann.fastimage"
+        },
+        "ios": {
+            "componentProvider": {
+                "FastImageView": "FFFastImageViewComponentView"
+            }
         }
     },
     "packageManager": "yarn@3.6.4"


### PR DESCRIPTION
## Summary:

Currently this package is not supported on react native version 0.80 and above because of couroutine in case of Ios. This PR resolves this issue and 

## Changelog:

Example: 
- [IOS] [ADDED] - Added support of react native 0.80.0 and above

## Test Plan:

Just test a sample case of fast image with `onError` and other callbacks on react native 0.80.0 version