### PR TITLE
fix: [Android] Custom source headers being applied correctly

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -96,7 +96,7 @@ class FastImageViewConverter {
         for (int i = 0; i < headersArray.size(); i++) {
             ReadableMap headerEntry = headersArray.getMap(i);
 
-            String header = headerEntry.hasKey("header") ? headerEntry.getString("header") : null;
+            String header = headerEntry.hasKey("name") ? headerEntry.getString("name") : null;
             String value = headerEntry.hasKey("value") ? headerEntry.getString("value") : null;
 
             if (header != null && value != null) {


### PR DESCRIPTION
## Summary:

On Android, image sourced with custom headers were not loading correctly. The "header" was not found because it was named as "name". This replaced the custom headers with the default headers.

## Changelog:

[ANDROID] [FIXED] - Custom source headers being applied correctly

## Test Plan:

- Load image with custom headers, for example with authorization required
- Image should load correctly