### PR TITLE
fix: react native error in strict bridgless mode (iOS)

### DIFF
--- a/ios/FastImage/FFFastImageViewManager.h
+++ b/ios/FastImage/FFFastImageViewManager.h
@@ -1,5 +1,9 @@
 #import <React/RCTViewManager.h>
 
+#if !defined(RCT_NEW_ARCH_ENABLED) || RCT_NEW_ARCH_ENABLED == 0
+
 @interface FFFastImageViewManager : RCTViewManager
 
 @end
+
+#endif

--- a/ios/FastImage/FFFastImageViewManager.mm
+++ b/ios/FastImage/FFFastImageViewManager.mm
@@ -6,6 +6,9 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <RNFastImageSpec/RNFastImageSpec.h>
 #endif
+
+#if !defined(RCT_NEW_ARCH_ENABLED) || RCT_NEW_ARCH_ENABLED == 0
+
 @implementation FFFastImageViewManager
 
 RCT_EXPORT_MODULE(FastImageView)
@@ -59,3 +62,5 @@ RCT_EXPORT_METHOD(clearDiskCache:(RCTPromiseResolveBlock)resolve reject:(RCTProm
 #endif
 
 @end
+
+#endif


### PR DESCRIPTION
## Summary:

Resolved #291 

This change prevents React Native from complaining about `*ViewManager` code in Bridgeless mode when strict checks are enabled: `RCTNewArchitectureSetMinValidationLevel(RCTNotAllowedInBridgeless)`.

In our app we use it to ensure all deps are compatible with Bridgeless/New Arch.

## Changelog:

- [IOS] [FIXED] - Fixed ViewManager error in strict Bridgeless mode

## Test Plan:

Apply the patch in #291 repro validation repo and confirm the lack of red box error: https://github.com/mdjastrzebski/repro-fast-image-new-arch

