### PR TITLE
feat(android): added support for 16 kb page size

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,14 +80,17 @@ repositories {
     mavenCentral()
 }
 
-def glideVersion = safeExtGet('glideVersion', '4.14.2')
+def glideVersion = safeExtGet('glideVersion', '4.16.0')
 
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation "com.github.bumptech.glide:glide:${glideVersion}"
     implementation "com.github.bumptech.glide:okhttp3-integration:${glideVersion}"
-    implementation "com.github.bumptech.glide:avif-integration:${glideVersion}"
-    implementation "com.github.zjupure:webpdecoder:2.6.${glideVersion}"
+    implementation 'org.aomedia.avif.android:avif:1.1.1.14d8e3c4'
+    implementation ("com.github.bumptech.glide:avif-integration:4.16.0") {
+        exclude group: 'org.aomedia.avif.android', module: 'avif'
+    }
+    implementation "com.github.zjupure:webpdecoder:2.7.${glideVersion}"
     annotationProcessor "com.github.bumptech.glide:compiler:${glideVersion}"
 }


### PR DESCRIPTION
## Summary:

This PR adds support for 16KB page size on Android.
Fixes: https://github.com/dream-sports-labs/react-native-fast-image/issues/280

## Changelog:

[ANDROID] [CHANGED] - Upgraded glide, avif and webpdecoder to support 16 KB page size.

## Test Plan:

Before change:
<img width="1352" height="624" alt="Screenshot 2025-07-25 at 9 56 21 PM" src="https://github.com/user-attachments/assets/81f67291-3df5-48af-8035-8ddeda746c7d" />


After Upgrades:
<img width="909" height="669" alt="Screenshot 2025-07-25 at 9 53 00 PM" src="https://github.com/user-attachments/assets/18a1c01c-9a02-487c-893b-92c86b1071e4" />

