### PR TITLE
feat: support `src`, `referrerPolicy`, `crossOrigin`, `height`, `width` (WIP)

### DIFF
--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`FastImage (Android) renders a non-existing defaultSource 1`] = `
         "height": 44,
         "width": 44,
       },
+      {},
     ]
   }
 >
@@ -41,6 +42,7 @@ exports[`FastImage (Android) renders a normal defaultSource 1`] = `
         "height": 44,
         "width": 44,
       },
+      {},
     ]
   }
 >
@@ -71,12 +73,100 @@ exports[`FastImage (Android) renders a normal defaultSource when fails to load s
         "height": 44,
         "width": 44,
       },
+      {},
     ]
   }
 >
   <FastImageView
     defaultSource={null}
     resizeMode="cover"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`FastImage (Android) renders with src prop 1`] = `
+<View
+  style={
+    [
+      {
+        "overflow": "hidden",
+      },
+      {
+        "height": 44,
+        "width": 44,
+      },
+      {},
+    ]
+  }
+>
+  <FastImageView
+    defaultSource={null}
+    resizeMode="cover"
+    source={
+      {
+        "headers": [],
+        "height": undefined,
+        "uri": "https://facebook.github.io/react/img/logo_og.png",
+        "width": undefined,
+      }
+    }
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`FastImage (Android) renders with src, referrerPolicy, crossOrigin, width, and height props 1`] = `
+<View
+  style={
+    [
+      {
+        "overflow": "hidden",
+      },
+      undefined,
+      {
+        "height": 100,
+        "width": 100,
+      },
+    ]
+  }
+>
+  <FastImageView
+    defaultSource={null}
+    resizeMode="cover"
+    source={
+      {
+        "headers": [
+          {
+            "name": "Access-Control-Allow-Credentials",
+            "value": "true",
+          },
+          {
+            "name": "Referrer-Policy",
+            "value": "no-referrer",
+          },
+        ],
+        "height": 100,
+        "uri": "https://facebook.github.io/react/img/logo_og.png",
+        "width": 100,
+      }
+    }
     style={
       {
         "bottom": 0,
@@ -101,6 +191,7 @@ exports[`FastImage (iOS) renders 1`] = `
         "height": 44,
         "width": 44,
       },
+      {},
     ]
   }
 >
@@ -145,6 +236,7 @@ exports[`FastImage (iOS) renders Image with fallback prop 1`] = `
           "right": 0,
           "top": 0,
         },
+        {},
         {
           "tintColor": undefined,
         },
@@ -165,6 +257,7 @@ exports[`FastImage (iOS) renders a normal Image when not passed a uri 1`] = `
         "height": 44,
         "width": 44,
       },
+      {},
     ]
   }
 >
@@ -195,12 +288,100 @@ exports[`FastImage (iOS) renders defaultSource 1`] = `
         "height": 44,
         "width": 44,
       },
+      {},
     ]
   }
 >
   <FastImageView
     defaultSource="[object Object]"
     resizeMode="cover"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`FastImage (iOS) renders with src prop 1`] = `
+<View
+  style={
+    [
+      {
+        "overflow": "hidden",
+      },
+      {
+        "height": 44,
+        "width": 44,
+      },
+      {},
+    ]
+  }
+>
+  <FastImageView
+    defaultSource={null}
+    resizeMode="cover"
+    source={
+      {
+        "headers": [],
+        "height": undefined,
+        "uri": "https://facebook.github.io/react/img/logo_og.png",
+        "width": undefined,
+      }
+    }
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`FastImage (iOS) renders with src, referrerPolicy, crossOrigin, width, and height props 1`] = `
+<View
+  style={
+    [
+      {
+        "overflow": "hidden",
+      },
+      undefined,
+      {
+        "height": 100,
+        "width": 100,
+      },
+    ]
+  }
+>
+  <FastImageView
+    defaultSource={null}
+    resizeMode="cover"
+    source={
+      {
+        "headers": [
+          {
+            "name": "Access-Control-Allow-Credentials",
+            "value": "true",
+          },
+          {
+            "name": "Referrer-Policy",
+            "value": "no-referrer",
+          },
+        ],
+        "height": 100,
+        "uri": "https://facebook.github.io/react/img/logo_og.png",
+        "width": 100,
+      }
+    }
     style={
       {
         "bottom": 0,

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -61,6 +61,29 @@ describe('FastImage (iOS)', () => {
         )
         expect(toJSON()).toMatchSnapshot()
     })
+
+    it('renders with src prop', () => {
+        const { toJSON } = render(
+            <FastImage
+                src="https://facebook.github.io/react/img/logo_og.png"
+                style={style.image}
+            />,
+        )
+        expect(toJSON()).toMatchSnapshot()
+    })
+
+    it('renders with src, referrerPolicy, crossOrigin, width, and height props', () => {
+        const { toJSON } = render(
+            <FastImage
+                src="https://facebook.github.io/react/img/logo_og.png"
+                referrerPolicy="no-referrer"
+                crossOrigin="use-credentials"
+                width={100}
+                height={100}
+            />,
+        )
+        expect(toJSON()).toMatchSnapshot()
+    })
 })
 
 describe('FastImage (Android)', () => {
@@ -94,6 +117,29 @@ describe('FastImage (Android)', () => {
     it('renders a non-existing defaultSource', () => {
         const { toJSON } = render(
             <FastImage defaultSource={12345} style={style.image} />,
+        )
+        expect(toJSON()).toMatchSnapshot()
+    })
+
+    it('renders with src prop', () => {
+        const { toJSON } = render(
+            <FastImage
+                src="https://facebook.github.io/react/img/logo_og.png"
+                style={style.image}
+            />,
+        )
+        expect(toJSON()).toMatchSnapshot()
+    })
+
+    it('renders with src, referrerPolicy, crossOrigin, width, and height props', () => {
+        const { toJSON } = render(
+            <FastImage
+                src="https://facebook.github.io/react/img/logo_og.png"
+                referrerPolicy="no-referrer"
+                crossOrigin="use-credentials"
+                width={100}
+                height={100}
+            />,
         )
         expect(toJSON()).toMatchSnapshot()
     })


### PR DESCRIPTION
## Summary:

Align Fast Image props more closely to React Native Image props by providing following props:
- `src`
- `referrerPolicy`
- `crossOrigin`
- `height`
- `width`

## Changelog:

- [GENERAL] [ADDED] - Support for web props: `src`, `referrerPolicy`, `crossOrigin`, `height`, `width`

## Test Plan:

Run example 