### PR TITLE
Added onComplete and onProgress callbacks to preload

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,18 @@ If using [ProGuard](https://www.guardsquare.com/proguard), add these rules to `a
 
 | Method                           | Description                                                                                              |
 |----------------------------------|----------------------------------------------------------------------------------------------------------|
-| `FastImage.preload(sources: object[])`   | Preloads images for faster display when they are rendered. <br> Example: `FastImage.preload([{ uri: "https://unsplash.it/400/400?image=1" }])`. |
+| `FastImage.preload(sources: object[], callbacks?: PreloadCallbacks)`   | Preloads images for faster display when they are rendered. <br> Optional callbacks for when each image loads or when all images are loaded can be provided. <br> Example: `FastImage.preload([{ uri: "https://unsplash.it/400/400?image=1" }], {onComplete, onProgress})`. |
 | `FastImage.clearMemoryCache(): Promise<void>`   | Clears all images from the memory cache.                                                                 |
 | `FastImage.clearDiskCache(): Promise<void>`     | Clears all images from the disk cache.                                                                   |
+
+
+    
+### Interfaces
+#### `PreloadCallbacks`
+| Field                           | Description                                                                                              |
+|----------------------------------|----------------------------------------------------------------------------------------------------------|
+| `onProgress?(loadedCount: number, totalCount: number): void`  | Called each time an image is loaded, or fails to load, along with the total number of images currently being processed. |
+| `onComplete?(finishedCount: number, skippedCount: number): void` | Called once all images are loaded. `finishedCount` is how many images were sucessfully preloaded, `skippedCount` is how many images either failed to load or had empty/invalid URIs. |
 
 ## 👥 Contributing
 

--- a/ReactNativeFastImageExample/src/PreloadExample.tsx
+++ b/ReactNativeFastImageExample/src/PreloadExample.tsx
@@ -7,19 +7,43 @@ import FeatureText from './FeatureText';
 import Button from './Button';
 // @ts-ignore
 import {createImageProgress} from 'react-native-image-progress';
-import {useCacheBust} from './useCacheBust';
+import {useCacheArrayBust} from './useCacheBust';
 
-const IMAGE_URL =
-  'https://cdn-images-1.medium.com/max/1600/1*-CY5bU4OqiJRox7G00sftw.gif';
+
+const IMAGE_URL = 'https://cdn-images-1.medium.com/max/1600/1*-CY5bU4OqiJRox7G00sftw.gif';
+
+const IMAGE_COUNT = 3;
+
 
 const Image = createImageProgress(FastImage);
 
 export const PreloadExample = () => {
   const [show, setShow] = useState(false);
-  const {url, bust} = useCacheBust(IMAGE_URL);
+  const [preloadDone, setPreloadDone] = useState(false);
+  const [totalToPreload, setTotalToPreload] = useState(0);
+  const [loadedCount, setLoadedCount] = useState(0);
+
+  const {urls, bust} = useCacheArrayBust(Array(IMAGE_COUNT).fill(IMAGE_URL));
+
+  const onPreloadComplete = () => {
+    setPreloadDone(true);
+  };
+
+  const onProgress = (loadedCount: number, totalCount: number) => {
+    setTotalToPreload(totalCount);
+    setLoadedCount(loadedCount);
+    console.log(`Preloading progress: ${loadedCount} / ${totalCount}`);
+  };
+
+  const onBust = () => {
+    bust();
+    setPreloadDone(false);
+    setLoadedCount(0);
+    setTotalToPreload(0);
+  }
 
   const preload = () => {
-    FastImage.preload([{uri: url}]);
+    FastImage.preload(urls.map((url) => ({uri: url})), {onProgress, onComplete: onPreloadComplete});
   };
 
   return (
@@ -29,14 +53,19 @@ export const PreloadExample = () => {
         <FeatureText text="• Progress indication using react-native-image-progress." />
       </Section>
       <SectionFlex style={styles.section}>
-        {show ? (
-          <Image style={styles.image} source={{uri: url}} />
-        ) : (
-          <View style={styles.image} />
-        )}
+        
+          <View style={styles.imageView}>
+          {urls.map((url, index) => show ?(
+              <Image key={index} style={styles.image} source={{uri: url}} />
+            ) : (
+              <View key={index} style={styles.image} />
+            ))}
+          </View>
+        <FeatureText text={`Progress: ${loadedCount}/${totalToPreload}`} />
+        <FeatureText text={preloadDone ? "Preload complete." : "Preload not run."} />
         <View style={styles.buttons}>
           <View style={styles.buttonView}>
-            <Button text="Bust" onPress={bust} />
+            <Button text="Bust" onPress={onBust} />
           </View>
           <View style={styles.buttonView}>
             <Button text="Preload" onPress={preload} />
@@ -63,6 +92,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     marginHorizontal: 20,
     marginBottom: 10,
+  },
+  imageView: {
+    padding: 20,
+    flexDirection: 'row',
   },
   image: {
     backgroundColor: '#ddd',

--- a/ReactNativeFastImageExample/src/useCacheBust.tsx
+++ b/ReactNativeFastImageExample/src/useCacheBust.tsx
@@ -16,3 +16,18 @@ export const useCacheBust = (
         bust,
     }
 }
+
+export const useCacheArrayBust = (
+    urls: string[],
+): {bust: () => void; urls: string[]; queries: string[]} => {
+    const [keys, setKeys] = useState(Array(urls.length).fill(getNewKey()))
+    const bust = useCallback(() => {
+        setKeys(Array(urls.length).fill(getNewKey()))
+    }, [])
+    const queries = keys.map(key => `?bust=${key}`)
+    return {
+        urls: urls.map((u, i) => `${u}${queries[i]}`),
+        queries,
+        bust,
+    }
+}

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModuleImplementation.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModuleImplementation.java
@@ -1,16 +1,30 @@
 package com.dylanvann.fastimage;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import android.app.Activity;
+import android.graphics.drawable.Drawable;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
+import com.bumptech.glide.request.target.Target;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.views.imagehelper.ImageSource;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 class FastImageViewModuleImplementation {
     ReactApplicationContext reactContext;
@@ -21,23 +35,77 @@ class FastImageViewModuleImplementation {
 
     public static final String REACT_CLASS = "FastImageViewModule";
 
+    public static final String PROGRESS_EVENT_NAME = "FastImagePreloadProgress";
+
+
+    public Map<String, Object> getConstants() {
+        final Map<String, Object> constants = new HashMap<>();
+        constants.put("FAST_IMAGE_PROGRESS_EVENT", PROGRESS_EVENT_NAME);
+        return constants;
+    }
+
+    public void addListener(String eventName) {}
+
+    public void removeListeners(Integer count) {}
+
     private Activity getCurrentActivity(){
         return reactContext.getCurrentActivity();
     }
 
-    public void preload(final ReadableArray sources) {
+    private void sendPreloadProgressEvent(int loaded, int total) {
+
+        WritableMap eventData = Arguments.createMap();
+        eventData.putInt("loaded", loaded);
+        eventData.putInt("total", total);
+
+        reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit(PROGRESS_EVENT_NAME, eventData);
+    }
+
+    public void preload(final ReadableArray sources, final Callback onComplete) {
         final Activity activity = getCurrentActivity();
-        if (activity == null) return;
+        if (activity == null) {
+            if (onComplete != null) {
+                onComplete.invoke(0, 0);
+            }
+            sendPreloadProgressEvent(0, 0);
+            return;
+        }
         activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
+
+                final AtomicInteger remainingTasks = new AtomicInteger(sources.size());
+                final AtomicInteger successfulTasks = new AtomicInteger(0);
+                final AtomicInteger skippedTasks = new AtomicInteger(0);
+
+                if (remainingTasks.get() == 0) {
+                    if (onComplete != null) {
+                        onComplete.invoke(0, 0);
+                    }
+                    sendPreloadProgressEvent(0, 0);
+                    return;
+                }
+
                 for (int i = 0; i < sources.size(); i++) {
                     final ReadableMap source = sources.getMap(i);
                     final FastImageSource imageSource = FastImageViewConverter.getImageSource(activity, source);
                     if (source == null || !source.hasKey("uri") || source.getString("uri").isEmpty()) {
-                            System.out.println("Source is null or URI is empty");
-                            continue;
-                          }
+                        System.out.println("Source is null or URI is empty");
+
+                        skippedTasks.incrementAndGet();
+
+                        sendPreloadProgressEvent(successfulTasks.get()+skippedTasks.get(), sources.size());
+
+                        if (remainingTasks.decrementAndGet() <= 0) {
+                            if (onComplete != null) {
+                                onComplete.invoke(successfulTasks.get(), skippedTasks.get());
+                            }
+                        }
+
+                        continue;
+                    }
+
                     Glide
                             .with(activity.getApplicationContext())
                             // This will make this work for remote and local images. e.g.
@@ -51,6 +119,31 @@ class FastImageViewModuleImplementation {
                                     imageSource.isResource() ? imageSource.getUri() : imageSource.getGlideUrl()
                             )
                             .apply(FastImageViewConverter.getOptions(activity, imageSource, source))
+                            .listener(new RequestListener<Drawable>() {
+                                @Override
+                                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
+                                    skippedTasks.incrementAndGet();
+
+                                    sendPreloadProgressEvent(successfulTasks.get()+skippedTasks.get(), sources.size());
+
+                                    if (remainingTasks.decrementAndGet() <= 0 && onComplete != null) {
+                                        onComplete.invoke(successfulTasks.get(), skippedTasks.get());
+                                    }
+                                    return false;
+                                }
+
+                                @Override
+                                public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                                    successfulTasks.incrementAndGet();
+
+                                    sendPreloadProgressEvent(successfulTasks.get()+skippedTasks.get(), sources.size());
+
+                                    if (remainingTasks.decrementAndGet() <= 0 && onComplete != null) {
+                                        onComplete.invoke(successfulTasks.get(), skippedTasks.get());
+                                    }
+                                    return false;
+                                }
+                            })
                             .preload();
                 }
             }

--- a/android/src/newarch/java/com/FastImageViewModule.java
+++ b/android/src/newarch/java/com/FastImageViewModule.java
@@ -1,5 +1,8 @@
 package com.dylanvann.fastimage;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import android.app.Activity;
 
 import androidx.annotation.NonNull;
@@ -13,6 +16,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.views.imagehelper.ImageSource;
+import com.facebook.react.bridge.Callback;
 
 class FastImageViewModule extends NativeFastImageViewModuleSpec {
 
@@ -23,6 +27,11 @@ class FastImageViewModule extends NativeFastImageViewModuleSpec {
         impl = new FastImageViewModuleImplementation(reactContext);
     }
 
+    @Override
+    public Map<String, Object> getConstants() {
+        return impl.getConstants();
+    }
+
     @NonNull
     @Override
     public String getName() {
@@ -30,8 +39,8 @@ class FastImageViewModule extends NativeFastImageViewModuleSpec {
     }
 
     @Override
-    public void preload(final ReadableArray sources) {
-        impl.preload(sources);
+    public void preload(final ReadableArray sources, final Callback onComplete) {
+        impl.preload(sources, onComplete);
     }
 
     @Override
@@ -42,5 +51,15 @@ class FastImageViewModule extends NativeFastImageViewModuleSpec {
     @Override
     public void clearDiskCache(Promise promise) {
         impl.clearDiskCache(promise);
+    }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+        impl.addListener(eventName);
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        impl.removeListeners(count);
     }
 }

--- a/android/src/oldarch/java/com/FastImageViewModule.java
+++ b/android/src/oldarch/java/com/FastImageViewModule.java
@@ -1,5 +1,8 @@
 package com.dylanvann.fastimage;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import android.app.Activity;
 
 import androidx.annotation.NonNull;
@@ -13,6 +16,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.views.imagehelper.ImageSource;
+import com.facebook.react.bridge.Callback;
 
 class FastImageViewModule extends ReactContextBaseJavaModule {
 
@@ -23,6 +27,11 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
         impl = new FastImageViewModuleImplementation(reactContext);
     }
 
+    @Override
+    public Map<String, Object> getConstants() {
+        return impl.getConstants();
+    }
+
     @NonNull
     @Override
     public String getName() {
@@ -30,8 +39,8 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void preload(final ReadableArray sources) {
-        impl.preload(sources);
+    public void preload(final ReadableArray sources, final Callback onComplete) {
+        impl.preload(sources, onComplete);
     }
 
     @ReactMethod
@@ -42,5 +51,15 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void clearDiskCache(Promise promise) {
         impl.clearDiskCache(promise);
+    }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+        impl.addListener(eventName);
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        impl.removeListeners(count);
     }
 }

--- a/ios/FastImage/FFFastImageViewModule.h
+++ b/ios/FastImage/FFFastImageViewModule.h
@@ -6,9 +6,9 @@
 
 #else
 
-#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface FFFastImageViewModule : NSObject <RCTBridgeModule>
+@interface FFFastImageViewModule : RCTEventEmitter
 
 #endif
 

--- a/src/NativeFastImageViewModule.ts
+++ b/src/NativeFastImageViewModule.ts
@@ -3,7 +3,12 @@ import { TurboModuleRegistry } from 'react-native'
 import { Source } from './index'
 
 export interface Spec extends TurboModule {
-    preload: (sources: Source[]) => void
+    addListener(eventName: string): void
+    removeListeners(count: number): void
+    preload: (
+        sources: Source[],
+        onComplete?: (finished: number, skipped: number) => void,
+    ) => void
     clearMemoryCache: () => Promise<void>
     clearDiskCache: () => Promise<void>
 }


### PR DESCRIPTION
## Summary:

Currently, `FastImage.preload` is a fire-and-forget method, with no way of checking when the function completes. This PR provides optional callbacks for `onComplete` and `onProgress`, which would make it easier to display things such as loading screens.

This is in particular responding to [this issue](https://github.com/dream-sports-labs/react-native-fast-image/issues/257)

## Changelog:

[GENERAL] [ADDED] - Added `onComplete` and `onProgress` callbacks to `FastImage.preload`

## Test Plan:

I have updated the Preloading section of the Example package, and confirmed it works on both iOS and Android. 

| Before preload | After Preload |
| - | - |
| <img width="392" height="306" alt="Screenshot 2025-08-15 at 16 07 54" src="https://github.com/user-attachments/assets/3a901cac-3629-4046-a674-ce7ed141e627" /> | <img width="407" height="346" alt="Screenshot 2025-08-15 at 16 08 05" src="https://github.com/user-attachments/assets/35365655-a578-4d16-b2d3-337c146b7a60" /> |
| Logs triggered on each `onProgress` | Updated code in example |
| <img width="301" height="78" alt="Screenshot 2025-08-15 at 16 08 10" src="https://github.com/user-attachments/assets/c36b448b-0e92-4fef-8331-526d6bfc4413" /> | <img width="896" height="858" alt="Screenshot 2025-08-15 at 16 08 50" src="https://github.com/user-attachments/assets/233a85a8-dcc6-4f6a-8c7a-4c0d1309ef95" /> |



 