### PR TITLE
Fix a build issue on Android with Expo 54

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -105,6 +105,6 @@ dependencies {
     // TODO: Make this configurable as it increases apk size by 900KB
     implementation 'com.github.penfeizhou.android.animation:glide-plugin:3.0.5'
     if (!isSvgDisabled()) {
-        implementation "com.caverock:androidsvg:1.4"
+        implementation "com.caverock:androidsvg-aar:1.4"
     }
 }


### PR DESCRIPTION
## Summary:

Another dependency in the Expo/react-native ecosystem has brought in `com.caverock:androidsvg-aar:1.4`, the aar version of the library, which causes duplicate symbols errors when linking.

## Changelog:

[ANDROID] [FIXED] - Updated `com.caverock:androidsvg` dependency to use the `aar` version.

## Test Plan:

Our app now builds, runs, and loads images just fine on Android.