### PR TITLE
fix iOS support default image (new architecture).

### DIFF
--- a/ReactNativeFastImageExample/ios/Podfile
+++ b/ReactNativeFastImageExample/ios/Podfile
@@ -1,3 +1,5 @@
+
+ENV['RCT_NEW_ARCH_ENABLED'] = '1'
 # Resolve react_native_pods.rb with node to allow for hoisting
 require Pod::Executable.execute_command('node', ['-p',
   'require.resolve(

--- a/ReactNativeFastImageExample/src/PriorityExample.tsx
+++ b/ReactNativeFastImageExample/src/PriorityExample.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {PixelRatio, StyleSheet, View} from 'react-native';
+import { PixelRatio, StyleSheet, View } from 'react-native';
 import FastImage from '@d11/react-native-fast-image';
 import Section from './Section';
 import SectionFlex from './SectionFlex';
 import FeatureText from './FeatureText';
-import {useCacheBust} from './useCacheBust';
+import { useCacheBust } from './useCacheBust';
 
 const getImageUrl = (id: string, width: number, height: number) =>
   `https://unsplash.it/${width}/${height}?image=${id}`;
@@ -17,7 +17,7 @@ const IMAGE_URLS = [
 ];
 
 export const PriorityExample = () => {
-  const {query, bust} = useCacheBust('');
+  const { query, bust } = useCacheBust('');
   return (
     <View>
       <Section>
@@ -26,10 +26,8 @@ export const PriorityExample = () => {
       <SectionFlex onPress={bust}>
         <FastImage
           style={styles.image}
-          source={{
-            uri: IMAGE_URLS[0] + query.replace('?', '&'),
-            priority: FastImage.priority.low,
-          }}
+          source={require('./images/logo.png')}
+          defaultSource={require('./images/logo.png')}
         />
         <FastImage
           style={styles.image}

--- a/ios/FastImage/FFFastImageViewComponentView.mm
+++ b/ios/FastImage/FFFastImageViewComponentView.mm
@@ -123,8 +123,10 @@ using namespace facebook::react;
     NSString *defaultSourceString = RCTNSStringFromStringNilIfEmpty(newViewProps.defaultSource);
     
     if (defaultSourceString && defaultSourceString.length > 0) {
-        UIImage *defaultImage = [RCTConvert UIImage:@{@"uri": defaultSourceString,@"__packager_asset": @YES}];
-        [fastImageView setDefaultSource:defaultImage];
+        if([[defaultSourceString lowercaseString] hasPrefix:@"http"]){
+            UIImage *defaultImage = [RCTConvert UIImage:@{@"uri": defaultSourceString,@"__packager_asset": @YES}];
+            [fastImageView setDefaultSource:defaultImage];
+        }
     }
     
 

--- a/ios/FastImage/FFFastImageViewComponentView.mm
+++ b/ios/FastImage/FFFastImageViewComponentView.mm
@@ -4,8 +4,11 @@
 #import "RCTConvert+FFFastImage.h"
 #import "FFFastImageView.h"
 
+#import <React/RCTConvert.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <React/RCTImageSource.h>
+#import <React/RCTUtils.h>
 #import <react/renderer/components/RNFastImageSpec/ComponentDescriptors.h>
 #import <react/renderer/components/RNFastImageSpec/Props.h>
 #import <react/renderer/components/RNFastImageSpec/EventEmitters.h>
@@ -115,6 +118,16 @@ using namespace facebook::react;
             break;
     }
     fastImageView.transition = transition;
+    
+    // Handle defaultSource
+    NSString *defaultSourceString = RCTNSStringFromStringNilIfEmpty(newViewProps.defaultSource);
+    
+    if (defaultSourceString && defaultSourceString.length > 0) {
+        UIImage *defaultImage = [RCTConvert UIImage:@{@"uri": defaultSourceString,@"__packager_asset": @YES}];
+        [fastImageView setDefaultSource:defaultImage];
+    }
+    
+
 
     [super updateProps:props oldProps:oldProps];
     // this method decides whether to reload the image based on changed props

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -168,6 +168,17 @@ const resolveDefaultSource = (
     if (!defaultSource) {
         return null
     }
+    if (isFabricEnabled) {
+        const resolved = Image.resolveAssetSource(
+            defaultSource as ImageRequireSource,
+        )
+
+        if (resolved) {
+            return resolved.uri
+        }
+        return null
+    }
+
     if (Platform.OS === 'android') {
         // Android receives a URI string, and resolves into a Drawable using RN's methods.
         const resolved = Image.resolveAssetSource(


### PR DESCRIPTION
## Summary:

Under the new architecture, the iOS version does not support setting the default image.

## Changelog:
 
- [iOS] [FIXED] - New Arch Support defaultSource

https://github.com/user-attachments/assets/8047e28a-c812-4711-b8a2-ab170a995b15



## Test Plan:
- Enable New Arch in Podfile
- Tested image with defaultSource
- Verified defaultSource behavior
- Tested on iOS 26
- Command: `cd ReactNativeFastImageExample && yarn ios`