### PR TITLE
feat: upgrade SDWebImage version

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -32,8 +32,8 @@ Pod::Spec.new do |s|
     s.source_files  = "ios/**/*.{h,mm}"
     s.dependency 'React-Core'
   end
-  s.dependency 'SDWebImage', '>= 5.19.1'
-  s.dependency 'SDWebImageWebPCoder', '~> 0.14'
+  s.dependency 'SDWebImage', '~> 5.21.0'
+  s.dependency 'SDWebImageWebPCoder', '~> 0.14.6'
   s.dependency 'SDWebImageAVIFCoder', '~> 0.11.0'
   if !disable_svg
     s.dependency 'SDWebImageSVGCoder', '~> 1.7.0'


### PR DESCRIPTION
## Summary:

This PR upgrades SDWebImage and SDWebImageWebPCoder to the latest version.

## Changelog:

- [iOS] [FIXED] - Upgraded SDWebImage and SDWebImageWebPCoder version

## Test Plan:

- Tested image loading with PNG, JPEG, GIF formats
- Verified cache behavior with `FastImage.preload()` 
- Tested on iOS 14 and Android 10
