### PR TITLE
feat: (iOS) Apply trilinear filtering to smooth out missized images

### DIFF
--- a/ios/FastImage/FFFastImageView.mm
+++ b/ios/FastImage/FFFastImageView.mm
@@ -119,6 +119,10 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
     [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
 #if !defined(DISABLE_SVG) || DISABLE_SVG == 0
     [[SDImageCodersManager sharedManager] addCoder:[SDImageSVGCoder sharedCoder]];
+
+    // Apply trilinear filtering to smooth out missized images
+    self.layer.minificationFilter = kCAFilterTrilinear;
+    self.layer.magnificationFilter = kCAFilterTrilinear;
 #endif
 }
 

--- a/ios/FastImage/FFFastImageView.mm
+++ b/ios/FastImage/FFFastImageView.mm
@@ -119,11 +119,10 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
     [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
 #if !defined(DISABLE_SVG) || DISABLE_SVG == 0
     [[SDImageCodersManager sharedManager] addCoder:[SDImageSVGCoder sharedCoder]];
-
+#endif
     // Apply trilinear filtering to smooth out missized images
     self.layer.minificationFilter = kCAFilterTrilinear;
     self.layer.magnificationFilter = kCAFilterTrilinear;
-#endif
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {


### PR DESCRIPTION
## Summary:

This PR improves quality of missized images by applying a trilinear filter.

## Changelog:

- [IOS] [ADDED] - Apply trilinear filtering to smooth out missized images

## Test Plan:

Use large image in smaller container view. Before update you can see that the straight lines are stepped, which is really noticeable. After this update image the straight lines on the image look much better as on screenshots below:

Before:
<img width="208" height="473" alt="Screenshot 2026-01-23 at 14 23 53" src="https://github.com/user-attachments/assets/39d81a76-2cab-4a2b-ba97-b327e2e68707" />

After:
<img width="210" height="474" alt="Screenshot 2026-01-23 at 14 33 04" src="https://github.com/user-attachments/assets/d7d1ee03-02ca-4d6d-ad35-f602fcb44506" />

