### PR TITLE
fix(ios): inject DISABLE_SVG preprocessor macro via podspec

### DIFF
--- a/RNFastImage.podspec
+++ b/RNFastImage.podspec
@@ -15,13 +15,17 @@ Pod::Spec.new do |s|
   s.framework = 'UIKit'
   s.requires_arc  = true
   s.source        = { :git => "https://github.com/dream-horizon-org/react-native-fast-image.git", :tag => "v#{s.version}" }
+  disable_svg_flag = disable_svg ? 'DISABLE_SVG=1' : ''
+
   if fabric_enabled
     folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
-    s.pod_target_xcconfig = {
+    xcconfig = {
       'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native"  "$(PODS_ROOT)/RCT-Folly"',
       "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
     }
+    xcconfig['GCC_PREPROCESSOR_DEFINITIONS'] = "$(inherited) #{disable_svg_flag}" if disable_svg
+    s.pod_target_xcconfig = xcconfig
     s.platforms       = { ios: '11.0', tvos: '11.0' }
     s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED'
     s.source_files    = 'ios/**/*.{h,m,mm,cpp}'
@@ -31,6 +35,7 @@ Pod::Spec.new do |s|
     s.platforms     = { :ios => "8.0", :tvos => "9.0" }
     s.source_files  = "ios/**/*.{h,mm}"
     s.dependency 'React-Core'
+    s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "$(inherited) #{disable_svg_flag}" } if disable_svg
   end
   s.dependency 'SDWebImage', '~> 5.21.0'
   s.dependency 'SDWebImageWebPCoder', '~> 0.14.6'


### PR DESCRIPTION
## Summary:
Fixes #379

When a user sets `DISABLE_SVG=1` before running `pod install`, the podspec correctly skips installing `SDWebImageSVGCoder` as a dependency. However, the `DISABLE_SVG` flag was never passed to the compiler as a preprocessor macro. This meant the `#if !defined(DISABLE_SVG)` guard in `FFFastImageView.mm` always evaluated as true (macro undefined), causing the source file to import `<SDWebImageSVGCoder/SDImageSVGCoder.h>` — a header that no longer exists on disk — resulting in a build failure:
````
'SDWebImageSVGCoder/SDImageSVGCoder.h' file not found
````
This PR fixes the disconnect by injecting `GCC_PREPROCESSOR_DEFINITIONS=DISABLE_SVG=1` into `pod_target_xcconfig` when the env var is set, so the compile-time guard matches what was excluded at pod install time.

Reproducer: https://github.com/kashmiry/rnfs-ios-svg-issue


## Changelog:

- [IOS] [FIXED] - Fixed Xcode build failure with `'SDWebImageSVGCoder/SDImageSVGCoder.h' file not found` when `DISABLE_SVG=1` is set before `pod install`

## Test Plan:

1. In a React Native < 0.80 project using `react-native-fast-image`:
export DISABLE_SVG=1
cd ios && pod install


2. Open in Xcode and build
3. **Before fix:** build fails with `'SDWebImageSVGCoder/SDImageSVGCoder.h' file not found`
4. **After fix:** build succeeds, SVG support is disabled as expected

- Verified SVG images do not load when `DISABLE_SVG=1` (expected behavior)
- Verified PNG/JPEG/WebP/AVIF images still load correctly
- Verified build succeeds without `DISABLE_SVG` set (SVG support intact)
- Tested on both old arch (RN < 0.80) and new arch (Fabric) paths

## Fix:
I was able to fix this and created a [PR](https://github.com/dream-horizon-org/react-native-fast-image/pull/380)