### PR TITLE
feat: add cacheKey support for <FastImage />

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you don't need SVG support, you can disable SVG decoders via an environment v
 - iOS (before running CocoaPods):
 
 ```bash
-export DISABLE_SVG=1 
+export DISABLE_SVG=1
 cd ios && pod install
 ```
 
@@ -148,11 +148,12 @@ If using [ProGuard](https://www.guardsquare.com/proguard), add these rules to `a
 
 | Property               | Type                       | Description                                                                                                                                                                                                                                             |
 |------------------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `source`               | `object`                   | Source for the remote image. Accepts an object with sub-properties like `uri`, `headers`, `priority`, and `cache`.                                                                                                                                      |
+| `source`               | `object`                   | Source for the remote image. Accepts an object with sub-properties like `uri`, `headers`, `priority`, `cache`, and `cacheKey`.                                                                                                                              |
 | `source.uri`           | `string`                   | The URL to load the image from. e.g., `"https://unsplash.it/400/400?image=1"`.                                                                                                                                                                          |
 | `source.headers`       | `object`                   | Headers to load the image with, e.g., `{ Authorization: "someAuthToken" }`.                                                                                                                                                                             |
 | `source.priority`      | `FastImage.priority`       | Load priority: <br> - `FastImage.priority.low` <br> - `FastImage.priority.normal` **(Default)** <br> - `FastImage.priority.high`                                                                                                                        |
 | `source.cache`         | `FastImage.cacheControl`   | Cache control: <br> - `FastImage.cacheControl.immutable` **(Default)** <br> - `FastImage.cacheControl.web` <br> - `FastImage.cacheControl.cacheOnly`                                                                                                     |
+| `source.cacheKey`      | `string`                   | Optional cache key used to identify image in cache. When set, overrides the URL as the cache key — allowing different URLs to share the same cache entry. `FastImage.preload` always caches by URL and ignores this.                                          |
 | `defaultSource`        | `number`                   | An asset loaded with `require()` or `import`. Note: on Android, `defaultSource` does not work in debug mode.                                                                                                                                            |
 | `resizeMode`           | `FastImage.resizeMode`     | Resize mode: <br> - `FastImage.resizeMode.contain` <br> - `FastImage.resizeMode.cover` **(Default)** <br> - `FastImage.resizeMode.stretch` <br> - `FastImage.resizeMode.center`                                  |
 | `transition`           | `FastImage.transition`     | transition applied when displaying the image: <br> - `FastImage.transition.none` **(Default)** <br> - `FastImage.transition.fade` (React Native Image equivalent)  |
@@ -174,6 +175,36 @@ If using [ProGuard](https://www.guardsquare.com/proguard), add these rules to `a
 | `FastImage.preload(sources: object[])`   | Preloads images for faster display when they are rendered. <br> Example: `FastImage.preload([{ uri: "https://unsplash.it/400/400?image=1" }])`. |
 | `FastImage.clearMemoryCache(): Promise<void>`   | Clears all images from the memory cache.                                                                 |
 | `FastImage.clearDiskCache(): Promise<void>`     | Clears all images from the disk cache.                                                                   |
+
+### Image caching with `cacheKey`
+
+Use `cacheKey` when the same image may be served from different URLs — for example, a CDN failover or a hostname change. FastImage will reuse the cached image as long as the key matches, regardless of the URL.
+
+```jsx
+// First load — cached under "profile-{filename}"
+<FastImage source={{ uri: 'https://cdn-a.example.com/images/users/{filename}.jpg', cacheKey: 'profile-{filename}' }} />
+
+// Later — different URL, same key → cache hit, no re-download
+<FastImage source={{ uri: 'https://cdn-b.example.com/images/users/{filename}.jpg', cacheKey: 'profile-{filename}' }} />
+```
+
+`cacheKey` also works for local-to-remote transitions. If an image is available locally before being uploaded, use the same key for both sources:
+
+```jsx
+import { Image } from 'react-native'
+
+const localAsset = require('./assets/photo.jpg')
+const { uri: localUri } = Image.resolveAssetSource(localAsset)
+
+// Image is local — cached under "profile-{filename}"
+<FastImage source={{ uri: localUri, cacheKey: 'profile-{filename}' }} />
+
+// Same image now on CDN — already cached, no re-download
+<FastImage source={{ uri: 'https://cdn.example.com/images/users/{filename}.jpg', cacheKey: 'profile-{filename}' }} />
+```
+
+> **Note:** `FastImage.preload` always caches by URL and does not respect `cacheKey`.
+> If different images accidentally share the same `cacheKey`, the last successful fetch wins.
 
 ## 👥 Contributing
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageGlideUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageGlideUrl.java
@@ -1,0 +1,18 @@
+package com.dylanvann.fastimage;
+
+import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.load.model.Headers;
+
+class FastImageGlideUrl extends GlideUrl {
+    private final String mCacheKey;
+
+    FastImageGlideUrl(String url, Headers headers, String cacheKey) {
+        super(url, headers);
+        mCacheKey = cacheKey;
+    }
+
+    @Override
+    public String getCacheKey() {
+        return mCacheKey;
+    }
+}

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageSource.java
@@ -22,6 +22,7 @@ public class FastImageSource {
     private static final String DATA_URI_PREFIX = "data:";
 
     private final Headers mHeaders;
+    @Nullable private final String mCacheKey;
     private Uri mUri;
     private String mSource;
 
@@ -46,14 +47,29 @@ public class FastImageSource {
     }
 
     public FastImageSource(Context context, String source) {
-        this(context, source, null);
+        this(context, source, null, null);
     }
 
     public FastImageSource(Context context, String source, @Nullable Headers headers) {
-        this(context, source, 0.0d, 0.0d, headers);
+        this(context, source, 0.0d, 0.0d, headers, null);
+    }
+
+    public FastImageSource(Context context, String source, @Nullable Headers headers, @Nullable String cacheKey) {
+        this(context, source, 0.0d, 0.0d, headers, cacheKey);
     }
 
     public FastImageSource(Context context, String source, double width, double height, @Nullable Headers headers) {
+        this(context, source, width, height, headers, null);
+    }
+
+    public FastImageSource(
+        Context context,
+        String source,
+        double width,
+        double height,
+        @Nullable Headers headers,
+        @Nullable String cacheKey
+    ) {
         ImageSource imageSource = new ImageSource(context, source, width, height);
         mSource = imageSource.getSource();
         mHeaders = headers == null ? Headers.DEFAULT : headers;
@@ -73,6 +89,8 @@ public class FastImageSource {
             String convertedUri = mUri.toString().replace("res:/", ANDROID_RESOURCE_SCHEME + "://" + context.getPackageName() + "/");
             mUri = Uri.parse(convertedUri);
         }
+
+        mCacheKey = cacheKey;
     }
 
     /**
@@ -184,6 +202,9 @@ public class FastImageSource {
     }
 
     public GlideUrl getGlideUrl() {
+        if (mCacheKey != null) {
+            return new FastImageGlideUrl(getUri().toString(), getHeaders(), mCacheKey);
+        }
         return new GlideUrl(getUri().toString(), getHeaders());
     }
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -15,6 +15,7 @@ import com.bumptech.glide.load.model.Headers;
 import com.bumptech.glide.load.model.LazyHeaders;
 import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.signature.ApplicationVersionSignature;
+import com.bumptech.glide.signature.ObjectKey;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.NoSuchKeyException;
 import com.facebook.react.bridge.ReadableArray;
@@ -55,9 +56,39 @@ class FastImageViewConverter {
     // Resolve the source uri to a file path that android understands.
     static @Nullable
     FastImageSource getImageSource(Context context, @Nullable ReadableMap source) {
+        return getImageSource(context, source, true);
+    }
+
+    static @Nullable
+    FastImageSource getImageSource(
+            Context context,
+            @Nullable ReadableMap source,
+            boolean includeCacheKey
+    ) {
+        String cacheKey = includeCacheKey ? getCacheKey(source) : null;
         return source == null
                 ? null
-                : new FastImageSource(context, source.getString("uri"), getHeaders(source));
+                : new FastImageSource(context, source.getString("uri"), getHeaders(source), cacheKey);
+    }
+
+    static @Nullable
+    String getCacheKey(@Nullable ReadableMap source) {
+        if (source == null || !source.hasKey("cacheKey")) {
+            return null;
+        }
+
+        ReadableType cacheKeyType = source.getType("cacheKey");
+        if (cacheKeyType != ReadableType.String) {
+            return null;
+        }
+
+        String cacheKey = source.getString("cacheKey");
+        if (cacheKey == null) {
+            return null;
+        }
+
+        String trimmedCacheKey = cacheKey.trim();
+        return trimmedCacheKey.isEmpty() ? null : trimmedCacheKey;
     }
 
     static Headers getHeaders(ReadableMap source) {
@@ -144,7 +175,13 @@ class FastImageViewConverter {
 
         options = FastImageBlurHelper.transform(context, options, imageOptions);
 
-        if (imageSource.isResource()) {
+        String cacheKey = getCacheKey(source);
+        if (cacheKey != null) {
+            // Respect custom cache keys for all source types.
+            options = options.apply(signatureOf(new ObjectKey(cacheKey)));
+        }
+
+        if (cacheKey == null && imageSource.isResource()) {
             // Every local resource (drawable) in Android has its own unique numeric id, which are
             // generated at build time. Although these ids are unique, they are not guaranteed unique
             // across builds. The underlying glide implementation caches these resources. To make

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModuleImplementation.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModuleImplementation.java
@@ -33,7 +33,7 @@ class FastImageViewModuleImplementation {
             public void run() {
                 for (int i = 0; i < sources.size(); i++) {
                     final ReadableMap source = sources.getMap(i);
-                    final FastImageSource imageSource = FastImageViewConverter.getImageSource(activity, source);
+                    final FastImageSource imageSource = FastImageViewConverter.getImageSource(activity, source, false);
                     if (source == null || !source.hasKey("uri") || source.getString("uri").isEmpty()) {
                             System.out.println("Source is null or URI is empty");
                             continue;

--- a/ios/FastImage/FFFastImageSource.h
+++ b/ios/FastImage/FFFastImageSource.h
@@ -24,10 +24,13 @@ typedef NS_ENUM(NSInteger, FFFCacheControl) {
 @property (nonatomic) NSDictionary *headers;
 // cache control mode
 @property (nonatomic) FFFCacheControl cacheControl;
+// optional cache key override for disk/memory cache identity
+@property (nonatomic, strong) NSString *cacheKey;
 
 - (instancetype)initWithURL:(NSURL *)url
                    priority:(FFFPriority)priority
                     headers:(NSDictionary *)headers
-               cacheControl:(FFFCacheControl)cacheControl;
+               cacheControl:(FFFCacheControl)cacheControl
+                   cacheKey:(NSString *)cacheKey;
 
 @end

--- a/ios/FastImage/FFFastImageSource.mm
+++ b/ios/FastImage/FFFastImageSource.mm
@@ -6,6 +6,7 @@
                    priority:(FFFPriority)priority
                     headers:(NSDictionary *)headers
                cacheControl:(FFFCacheControl)cacheControl
+                   cacheKey:(NSString *)cacheKey
 {
     self = [super init];
     if (self) {
@@ -13,6 +14,7 @@
         _priority = priority;
         _headers = headers;
         _cacheControl = cacheControl;
+        _cacheKey = cacheKey;
     }
     return self;
 }

--- a/ios/FastImage/FFFastImageView.mm
+++ b/ios/FastImage/FFFastImageView.mm
@@ -3,6 +3,7 @@
 #import <CoreImage/CoreImage.h>
 #import <SDWebImage/UIImage+MultiFormat.h>
 #import <SDWebImage/UIView+WebCache.h>
+#import <SDWebImage/SDWebImageCacheKeyFilter.h>
 #import <SDWebImageAVIFCoder/SDImageAVIFCoder.h>
 #import <SDWebImageWebPCoder/SDImageWebPCoder.h>
 #if !defined(DISABLE_SVG) || DISABLE_SVG == 0
@@ -273,7 +274,16 @@ static NSString * const kFFFastImageDefaultErrorMessage = @"Load failed";
             }
             return [mutableRequest copy];
         }];
-        SDWebImageContext* context = @{SDWebImageContextDownloadRequestModifier: requestModifier};
+        NSMutableDictionary *context = [@{
+            SDWebImageContextDownloadRequestModifier: requestModifier
+        } mutableCopy];
+        if (_source.cacheKey && _source.cacheKey.length > 0) {
+            NSString *cacheKey = _source.cacheKey;
+            context[SDWebImageContextCacheKeyFilter] =
+                [SDWebImageCacheKeyFilter cacheKeyFilterWithBlock:^NSString * _Nullable(NSURL * _Nonnull url) {
+                    return cacheKey;
+                }];
+        }
 
         // Set priority.
         SDWebImageOptions options = SDWebImageRetryFailed | SDWebImageHandleCookies;

--- a/ios/FastImage/FFFastImageViewComponentView.mm
+++ b/ios/FastImage/FFFastImageViewComponentView.mm
@@ -40,6 +40,7 @@ using namespace facebook::react;
 
     NSMutableDictionary *imageSourcePropsDict = [NSMutableDictionary new];
     imageSourcePropsDict[@"uri"] = RCTNSStringFromStringNilIfEmpty(newViewProps.source.uri);
+    imageSourcePropsDict[@"cacheKey"] = RCTNSStringFromStringNilIfEmpty(newViewProps.source.cacheKey);
     NSMutableDictionary* headers = [[NSMutableDictionary alloc] init];
     for (auto & element : newViewProps.source.headers) {
         [headers setValue:RCTNSStringFromString(element.value) forKey:RCTNSStringFromString(element.name)];

--- a/ios/FastImage/RCTConvert+FFFastImage.mm
+++ b/ios/FastImage/RCTConvert+FFFastImage.mm
@@ -25,6 +25,14 @@ RCT_ENUM_CONVERTER(FFFCacheControl, (@{
     
     FFFPriority priority = [self FFFPriority:json[@"priority"]];
     FFFCacheControl cacheControl = [self FFFCacheControl:json[@"cache"]];
+    id cacheKeyValue = json[@"cacheKey"];
+    NSString *cacheKey = nil;
+    if ([cacheKeyValue isKindOfClass:[NSString class]]) {
+        cacheKey = [(NSString *)cacheKeyValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (cacheKey.length == 0) {
+            cacheKey = nil;
+        }
+    }
     
     NSDictionary *headers = [self NSDictionary:json[@"headers"]];
     if (headers) {
@@ -43,7 +51,7 @@ RCT_ENUM_CONVERTER(FFFCacheControl, (@{
         }
     }
     
-    FFFastImageSource *imageSource = [[FFFastImageSource alloc] initWithURL:uri priority:priority headers:headers cacheControl:cacheControl];
+    FFFastImageSource *imageSource = [[FFFastImageSource alloc] initWithURL:uri priority:priority headers:headers cacheControl:cacheControl cacheKey:cacheKey];
     
     return imageSource;
 }

--- a/src/FastImageViewNativeComponent.ts
+++ b/src/FastImageViewNativeComponent.ts
@@ -17,6 +17,7 @@ type FastImageSource = Readonly<{
     headers?: Headers
     priority?: Priority
     cache?: CacheControl
+    cacheKey?: string
 }>
 
 type OnErrorEvent = Readonly<{

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -46,6 +46,7 @@ export type FastImageSource = {
     headers?: Object,
     priority?: Priorities,
     cache?: CacheControls,
+    cacheKey?: string,
 }
 
 export type FastImageProps = $ReadOnly<{|

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Platform, NativeModules } from 'react-native'
+import { StyleSheet, Platform, NativeModules, Image } from 'react-native'
 import React from 'react'
 import { render } from '@testing-library/react-native'
 import FastImage from './index'
@@ -60,6 +60,42 @@ describe('FastImage (iOS)', () => {
             />,
         )
         expect(toJSON()).toMatchSnapshot()
+    })
+
+    it('passes cacheKey to native source', () => {
+        const resolveSpy = jest
+            .spyOn(Image, 'resolveAssetSource')
+            .mockImplementation((src: any) => src)
+        const { UNSAFE_getByType } = render(
+            <FastImage
+                source={{
+                    uri: 'https://facebook.github.io/react/img/logo_og.png',
+                    cacheKey: 'logo-og',
+                }}
+                style={style.image}
+            />,
+        )
+        const nativeView = UNSAFE_getByType('FastImageView' as any)
+        expect(nativeView.props.source.cacheKey).toBe('logo-og')
+        resolveSpy.mockRestore()
+    })
+
+    it('ignores null cacheKey in native source', () => {
+        const resolveSpy = jest
+            .spyOn(Image, 'resolveAssetSource')
+            .mockImplementation((src: any) => src)
+        const { UNSAFE_getByType } = render(
+            <FastImage
+                source={{
+                    uri: 'https://facebook.github.io/react/img/logo_og.png',
+                    cacheKey: null as any,
+                }}
+                style={style.image}
+            />,
+        )
+        const nativeView = UNSAFE_getByType('FastImageView' as any)
+        expect(nativeView.props.source?.cacheKey).toBeUndefined()
+        resolveSpy.mockRestore()
     })
 })
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,6 +68,7 @@ export type Source = {
     headers?: { [key: string]: string }
     priority?: Priority
     cache?: Cache
+    cacheKey?: string
 }
 
 export interface OnLoadEvent {
@@ -206,6 +207,7 @@ function FastImageBase({
     if (fallback) {
         const cleanedSource = { ...(source as any) }
         delete cleanedSource.cache
+        delete cleanedSource.cacheKey
         const resolvedSource = Image.resolveAssetSource(cleanedSource)
 
         return (
@@ -235,8 +237,22 @@ function FastImageBase({
     const resolvedSource = Image.resolveAssetSource(
         source as any,
     ) as ImageResolvedAssetSource & { headers: any }
-    // resolvedSource would be frozen, we can't modify it
-    let modifiedSource = resolvedSource
+    // resolvedSource would be frozen, we can't modify it.
+    // Read cacheKey from the original source — resolveAssetSource may drop custom fields.
+    // Only forward non-empty strings; null/undefined/non-string must never reach native.
+    const rawCacheKey = (source as Source)?.cacheKey
+    const cacheKey =
+        typeof rawCacheKey === 'string' && rawCacheKey.length > 0
+            ? rawCacheKey
+            : undefined
+    let modifiedSource = resolvedSource as any
+    if (resolvedSource && typeof resolvedSource === 'object') {
+        const sourceWithoutCacheKey = { ...(resolvedSource as any) }
+        delete sourceWithoutCacheKey.cacheKey
+        modifiedSource = cacheKey
+            ? { ...sourceWithoutCacheKey, cacheKey }
+            : sourceWithoutCacheKey
+    }
     if (
         resolvedSource?.headers &&
         (FABRIC_ENABLED || Platform.OS === 'android')
@@ -246,7 +262,7 @@ function FastImageBase({
         Object.keys(resolvedSource.headers).forEach((key) => {
             headersArray.push({ name: key, value: resolvedSource.headers[key] })
         })
-        modifiedSource = { ...resolvedSource, headers: headersArray }
+        modifiedSource = { ...modifiedSource, headers: headersArray }
     }
     const resolvedDefaultSource = resolveDefaultSource(defaultSource)
     const resolvedDefaultSourceAsString =


### PR DESCRIPTION
## Summary:
This PR adds optional `cacheKey` support to `<FastImage />` `source` so apps can keep a stable cache identity even when image URLs change (for example backup CDNs | path migrations).
1. When `cacheKey` is provided, native cache lookup/store uses that key during normal `<FastImage />` rendering.  
2. When its not provided, existing URL-based behavior remains unchanged.

**Related:**
This could address the enhancement requested in #158.

## Changelog:

- [GENERAL] [ADDED] - Added optional `source.cacheKey` support for stable render-time cache identity across URL changes
- [IOS] [CHANGED] - Applied `cacheKey` to SDWebImage cache identity for `<FastImage />` render requests.
- [ANDROID] [CHANGED] - Applied `cacheKey` to Glide cache identity for `<FastImage />` render requests.
- [GENERAL] [CHANGED] - Updated README with `cacheKey` API docs and usage examples.
- [INTERNAL] [ADDED] - Added tests for `cacheKey` forwarding and `null` `cacheKey` normalization behavior.

## Test Plan:

- Verified that without `cacheKey`, behavior remains URL-based (backward-compatible).
- Verified that with same `cacheKey` and different URLs, render path reuses cache identity.
- Verified `cacheKey: null` is ignored safely and does not break loading.
- Verified test coverage for:
  - forwarding string `cacheKey`.
  - ignoring null `cacheKey` in native source props.
- Tested on app in both Android & iOS.
- Tested example app, working as expected.
- Tested command: `yarn lint` Result: **_pass_**
- Tested Command: `yarn test` Result: **_pass_**
  
## Additional Note:

`FastImage.preload()` support for `cacheKey` was intentionally not added in this PR to keep scope focused and avoid changing preload semantics.  
On iOS, adding `cacheKey` to preload would require moving away from `SDWebImagePrefetcher` behavior; on Android, preload is also kept URL-based by design in this PR.

Moving away from `SDWebImagePrefetcher` would likely mean losing or changing:
- prefetch-specific cancellation behavior.
- built-in prefetch coordination/throttling behavior.
- parity with existing iOS preload flow used by the library today.

This keeps the change backward-compatible and limited to `<FastImage />` usage.
Support for preload can be handled later in a dedicated PR focused specifically on preload behavior.