### PR TITLE
Support Expo SDK 55 with CNG

### DIFF
--- a/docs/app-glide-module.md
+++ b/docs/app-glide-module.md
@@ -9,3 +9,5 @@ project.ext {
     excludeAppGlideModule = true
 }
 ```
+
+If you can't make changes to the `android` folder because you are using [Continuous Native Generation](https://docs.expo.dev/workflow/continuous-native-generation/), place [this file](../plugins/withExcludeAppGlideModule.js) at `./plugins/withExcludeAppGlideModule.js` and add `"./plugins/withExcludeAppGlideModule.js"` to the `plugins` section of your `app.json`. Then, run `npx expo prebuild --clean` to regenerate the `android` folder.

--- a/plugins/withExcludeAppGlideModule.js
+++ b/plugins/withExcludeAppGlideModule.js
@@ -1,6 +1,6 @@
 const plugin = require("@expo/config-plugins");
 
-/** @type {import('@expo/config-plugins').ConfigPlugin} */
+/** @type {plugin.ConfigPlugin} */
 const withExcludeAppGlideModule = (config) => {
   const tab = "  "; // 2 spaces
   return plugin.withProjectBuildGradle(config, (config) => {

--- a/plugins/withExcludeAppGlideModule.js
+++ b/plugins/withExcludeAppGlideModule.js
@@ -1,0 +1,30 @@
+import plugin from "@expo/config-plugins";
+
+/** @type {import('@expo/config-plugins').ConfigPlugin} */
+const withExcludeAppGlideModule = (config) => {
+  const tab = "  "; // 2 spaces
+  return plugin.withProjectBuildGradle(config, (config) => {
+    if (config.modResults.language === "groovy") {
+      let buildGradle = config.modResults.contents;
+
+      if (!buildGradle.includes("excludeAppGlideModule = true")) {
+        const excludeAppGlideModule = `${tab}excludeAppGlideModule = true`;
+        const extBlock = /ext\s*\{/;
+        if (extBlock.test(buildGradle)) {
+          buildGradle = buildGradle.replace(
+            extBlock,
+            `ext {\n${excludeAppGlideModule}`,
+          );
+        } else {
+          buildGradle += `\nproject.ext {\n${excludeAppGlideModule}\n}\n`;
+        }
+      }
+
+      config.modResults.contents = buildGradle;
+    }
+
+    return config;
+  });
+};
+
+export default withExcludeAppGlideModule;

--- a/plugins/withExcludeAppGlideModule.js
+++ b/plugins/withExcludeAppGlideModule.js
@@ -1,4 +1,4 @@
-import plugin from "@expo/config-plugins";
+const plugin = require("@expo/config-plugins");
 
 /** @type {import('@expo/config-plugins').ConfigPlugin} */
 const withExcludeAppGlideModule = (config) => {
@@ -27,4 +27,4 @@ const withExcludeAppGlideModule = (config) => {
   });
 };
 
-export default withExcludeAppGlideModule;
+module.exports = withExcludeAppGlideModule;


### PR DESCRIPTION
## Summary:

This PR improves the documentation by adding specific instructions for Expo projects using the [Continuous Native Generation (CNG) workflow](https://docs.expo.dev/workflow/continuous-native-generation/), which is the most common and recommended approach nowadays. Since directly modifying the `android/build.gradle` file is not an option when using CNG, I added a guide and a code snippet for a custom Expo Config Plugin that safely injects `excludeAppGlideModule = true` during the prebuild phase.

## Changelog:

[ANDROID] [ADDED] - Added Expo CNG workflow instructions for excluding AppGlideModule

## Test Plan:

- Reviewed the markdown changes for clarity and formatting.
- Verified the provided Config Plugin script locally on an Expo SDK 55 project by running `npx expo prebuild --clean` and confirming the `excludeAppGlideModule = true` property was successfully injected into the generated `android/build.gradle`.