### PR TITLE
fix: support defaultSource on the New Architecture (Fabric) — iOS, Android & JS

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -35,6 +35,7 @@ class FastImageViewWithUrl extends AppCompatImageView {
     private boolean mNeedsReload = false;
     private ReadableMap mSource = null;
     private Drawable mDefaultSource = null;
+    private String mDefaultSourceUri = null;
     private int mBlurRadius = 0;
     private int mBlurRadiusPrevious = 0;
     public GlideUrl glideUrl;
@@ -52,6 +53,23 @@ class FastImageViewWithUrl extends AppCompatImageView {
     public void setDefaultSource(@Nullable Drawable source) {
         mNeedsReload = true;
         mDefaultSource = source;
+    }
+
+    public void setDefaultSourceUri(@Nullable String uri) {
+        mNeedsReload = true;
+        mDefaultSourceUri = uri;
+    }
+
+    private boolean showDefaultSource(@Nullable RequestManager requestManager) {
+        if (mDefaultSource != null) {
+            setImageDrawable(mDefaultSource);
+            return true;
+        }
+        if (requestManager != null && mDefaultSourceUri != null && !mDefaultSourceUri.isEmpty()) {
+            requestManager.load(mDefaultSourceUri).into(this);
+            return true;
+        }
+        return false;
     }
 
     public void setBlurRadius(@Nullable Integer blurRadius) {
@@ -93,8 +111,9 @@ class FastImageViewWithUrl extends AppCompatImageView {
                 FastImageOkHttpProgressGlideModule.forget(glideUrl.toStringUrl());
             }
 
-            // Clear the image.
-            setImageDrawable(null);
+            if (!showDefaultSource(requestManager)) {
+                setImageDrawable(null);
+            }
 
             ThemedReactContext context = (ThemedReactContext) getContext();
             EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
@@ -124,8 +143,9 @@ class FastImageViewWithUrl extends AppCompatImageView {
             if (glideUrl != null) {
                 FastImageOkHttpProgressGlideModule.forget(glideUrl.toStringUrl());
             }
-            // Clear the image.
-            setImageDrawable(null);
+            if (!showDefaultSource(requestManager)) {
+                setImageDrawable(null);
+            }
             return;
         }
 
@@ -163,7 +183,7 @@ class FastImageViewWithUrl extends AppCompatImageView {
         }
 
         if (requestManager != null) {
-            RequestBuilder<? extends Drawable> builder;
+            RequestBuilder<Drawable> builder;
             Map<String, Object> builderOptions = new HashMap<>();
             builderOptions.put("view", this);
             builderOptions.put("blurRadius", mBlurRadius);
@@ -176,6 +196,11 @@ class FastImageViewWithUrl extends AppCompatImageView {
                                 .getOptions(context, imageSource, mSource, builderOptions)
                                 .placeholder(mDefaultSource) // show until loaded
                                 .fallback(mDefaultSource)); // null will not be treated as error
+
+                if (mDefaultSource == null && mDefaultSourceUri != null && !mDefaultSourceUri.isEmpty()) {
+                    RequestBuilder<Drawable> defaultSource = requestManager.load(mDefaultSourceUri);
+                    builder = builder.thumbnail(defaultSource).error(defaultSource);
+                }
 
                 if (key != null) {
                     builder.listener(new FastImageRequestListener(key));

--- a/android/src/newarch/java/com/FastImageViewManager.java
+++ b/android/src/newarch/java/com/FastImageViewManager.java
@@ -80,6 +80,7 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
     @Override
     @ReactProp(name = "defaultSource")
     public void setDefaultSource(FastImageViewWithUrl view, @Nullable String source) {
+        view.setDefaultSourceUri(source);
         view.setDefaultSource(
                 ResourceDrawableIdHelper.getInstance()
                         .getResourceDrawable(view.getContext(), source));

--- a/ios/FastImage/FFFastImageViewComponentView.mm
+++ b/ios/FastImage/FFFastImageViewComponentView.mm
@@ -81,6 +81,13 @@ using namespace facebook::react;
 
     [fastImageView setSource: imageSource];
 
+    NSString *defaultSourceString = RCTNSStringFromStringNilIfEmpty(newViewProps.defaultSource);
+    if (defaultSourceString.length > 0) {
+        [fastImageView setDefaultSource: [RCTConvert UIImage: @{@"uri": defaultSourceString, @"__packager_asset": @YES}]];
+    } else {
+        [fastImageView setDefaultSource: nil];
+    }
+
 
     RCTResizeMode resizeMode;
     switch (newViewProps.resizeMode) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -168,6 +168,11 @@ const resolveDefaultSource = (
     if (!defaultSource) {
         return null
     }
+    // @ts-ignore non-typed property
+    const isFabricEnabled = Boolean(global?.nativeFabricUIManager)
+    if (isFabricEnabled) {
+        return Image.resolveAssetSource(defaultSource as ImageRequireSource)?.uri ?? null
+    }
     if (Platform.OS === 'android') {
         // Android receives a URI string, and resolves into a Drawable using RN's methods.
         const resolved = Image.resolveAssetSource(


### PR DESCRIPTION
## Problem

`defaultSource` is ignored when the New Architecture (Fabric) is enabled, so the
view stays blank while the remote image loads. Closes #385.

Root cause is per-platform:

- **iOS**: the Fabric component view (`FFFastImageViewComponentView.updateProps:`)
  handled `source`, `resizeMode`, etc. but never applied `defaultSource`.
- **JS**: under Fabric, `defaultSource` is typed as a `String` natively, but
  `resolveDefaultSource` returned the raw `require()` number on iOS, which was
  then `String()`-ified to e.g. `"42"` — unusable natively.
- **Android**: `setDefaultSource` only resolves a *local resource name* via
  `getResourceDrawable`; a packager/remote URI (debug) returns `null`, and no
  placeholder was shown when the source was empty/invalid.

## Fix

- **JS** (`src/index.tsx`): under Fabric, resolve the asset to a URI
  (`Image.resolveAssetSource(...).uri`).
- **iOS** (`FFFastImageViewComponentView.mm`): apply `defaultSource` in
  `updateProps:` by converting the URI to a `UIImage` via
  `{uri, __packager_asset: YES}` (works in debug *and* release). Builds on #355.
- **Android** (`FastImageViewWithUrl.java`, `FastImageViewManager.java`): keep the
  raw URI and, when it isn't a local `Drawable`, load the placeholder through
  Glide — `.thumbnail()` while loading, `.error()` on failure — and show it when
  there is no valid source.

## Tested

- iOS New Arch — debug & release ✅
- Android New Arch — debug & release ✅
- Placeholder shown while loading, on 404, and when no source is provided.