### PR TITLE
fix(android): release animated drawables when clearing FastImage views

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -11,9 +11,7 @@ import androidx.appcompat.widget.AppCompatImageView;
 import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.model.GlideUrl;
-import com.bumptech.glide.request.Request;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
-import com.bumptech.glide.load.resource.gif.GifDrawable;
 import com.facebook.react.bridge.ReadableMap;
 import com.dylanvann.fastimage.events.FastImageErrorEvent;
 import com.dylanvann.fastimage.events.FastImageLoadStartEvent;
@@ -194,8 +192,10 @@ class FastImageViewWithUrl extends AppCompatImageView {
     }
 
     public void clearView(@Nullable RequestManager requestManager) {
-        if (requestManager != null && getTag() != null && getTag() instanceof Request) {
+        if (requestManager != null) {
             requestManager.clear(this);
         }
+
+        setImageDrawable(null);
     }
 }


### PR DESCRIPTION
## Summary:

Fixes #386.

On Android, FastImage's `clearView()` only called `RequestManager.clear(view)` when the View's plain tag was a Glide `Request`. Issue #386 shows that this can skip Glide cleanup when the plain tag is not set or is not a `Request`, even though `onDropViewInstance` or a source update has called `clearView()`.

This change makes cleanup explicit and target-based:

- call `RequestManager.clear(view)` whenever a `RequestManager` is available
- detach the current drawable from the ImageView with `setImageDrawable(null)`

`RequestManager.clear(view)` is Glide's public cleanup API for canceling pending loads and freeing resources associated with a view. The existing `getTag() instanceof Request` guard is removed so FastImage no longer depends on Glide's internal view-tag storage details.

Glide already handles stopping `Animatable` resources from its target cleanup path, so this PR intentionally does not call `Animatable.stop()` directly from `FastImageViewWithUrl.clearView()`. Directly stopping the current drawable can affect consecutive targets that reuse or share the same animated resource.

In a downstream Android test case with many sequential animated WebP cards, playback previously started slowing down after roughly 30 cards and caused noticeable device heating. This cleanup change keeps Glide's target cleanup path active while avoiding direct animated drawable stops from FastImage itself.

Related to #350.

## Changelog:

- [ANDROID] [FIXED] - Fixed Android FastImage view cleanup so Glide requests are cleared and ImageView drawable references are detached

## Test Plan:

- `corepack yarn type-check`
- `cd ReactNativeFastImageExample/android && ./gradlew :app:compileDebugJavaWithJavac`

Also verified in a downstream Android app:

- removed the direct `Animatable.stop()` call
- kept `RequestManager.clear(view)` plus `setImageDrawable(null)`
- Android compile succeeded
- type-check and targeted eslint succeeded
- animated WebP swipe deck cleanup behavior was re-tested on a physical Android device

## Notes for reviewers:

- This intentionally calls `RequestManager.clear(view)` directly instead of checking `getTag()`.
- This intentionally does not call `Animatable.stop()` directly because Glide's target cleanup path already handles animatable stopping.
- `setImageDrawable(null)` is kept after Glide target cleanup so the ImageView does not retain the old drawable reference.
- This PR does not introduce cache-key or URL-fragment behavior changes; it only narrows FastImage view cleanup to Glide target clearing plus drawable detachment.